### PR TITLE
Fix unset mpFee for Payments by setting to 0

### DIFF
--- a/mp_csv_accounting.py
+++ b/mp_csv_accounting.py
@@ -657,6 +657,7 @@ def readTransactionsFromFile(filePath, mpNumber):
                     dateAndTime=row["Date and time"],
                     customerName=row["Customer name"],
                     comment=row["Comment"],
+                    mpFee="0",
                 )
 
                 newTrans.checkAndCommit()


### PR DESCRIPTION
The `Transaction.isDone()` check requires mpFee to be set, yet at https://github.com/jmkjaer/MpCsvAccounting/blob/daedcbe9003dcbe34355f449326e8aa0975c22b2/mp_csv_accounting.py#L653-L660 it is unset.

