### PR TITLE
Fix charset issue by whitelist

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1,7 +1,7 @@
 [stregsystem]
 
 # Number that people send money to via MP
-mp_number = 12345
+mp_number = 90601
 
 # Registration fee in øre
 registration_fee = 20000

--- a/mp_csv_accounting.py
+++ b/mp_csv_accounting.py
@@ -638,7 +638,9 @@ def readTransactionsFromFile(filePath, mpNumber):
     batches before bank transfer. Amount is in øre (1/100th of a krone).
     """
 
-    file = open(filePath, "r", newline="")
+    f = open(filePath, "r", newline="")
+    file = [re.sub('[^a-åA-Å0-9-;()!"+,.:?@óöü\s]', '', row) for row in f]
+    f.close()
     reader = csv.DictReader(file, delimiter=";")
 
     transactionBatches = []
@@ -728,8 +730,6 @@ def readTransactionsFromFile(filePath, mpNumber):
     if currentBatch.isActive():
         currentBatch.commit()
         transactionBatches.append(currentBatch)
-
-    file.close()
 
     return transactionBatches
 


### PR DESCRIPTION
Emoji and other non-latin1 chars were breaking the script.
This change whitelists chars I found in the last month of transactions which are non-breaking for the latin1 charset.